### PR TITLE
PROD-1929 Remove messages from work dashboard -> PROD-1521_PROD-1551_dashboard-and-header

### DIFF
--- a/src-ts/lib/work-provider/work-functions/work.functions.ts
+++ b/src-ts/lib/work-provider/work-functions/work.functions.ts
@@ -1,4 +1,4 @@
-import { messageGetAndSetForWorkItemsAsync } from '../../functions'
+// import { messageGetAndSetForWorkItemsAsync } from '../../functions'
 import { Page } from '../../pagination'
 
 import { Work, workFactoryCreate, WorkStatus, WorkType } from './work-factory'
@@ -18,6 +18,13 @@ export async function getAsync(handle: string, page: Page): Promise<Array<Work>>
         .map(challenge => workFactoryCreate(challenge))
         .filter(work => work.status !== WorkStatus.deleted && work.type !== WorkType.unknown)
 
+    return workItems
+
+    /*
+        TODO: add this data back to the work object when the bug is fixed:
+        https://topcoder.atlassian.net/browse/PROD-1860
+        Unread Messages count from API don't match embedded forum widget
     // get and set the messages counts and return
     return messageGetAndSetForWorkItemsAsync(workItems, handle)
+    */
 }

--- a/src-ts/tools/work/work-table/work-table.config.tsx
+++ b/src-ts/tools/work/work-table/work-table.config.tsx
@@ -43,12 +43,17 @@ export const workListColumns: Array<TableColumn<Work>> = [
         propertyName: 'cost',
         type: 'money',
     },
+    /*
+        TODO: add this column back when the bug is fixed:
+        https://topcoder.atlassian.net/browse/PROD-1860
+        Unread Messages count from API don't match embedded forum widget
     {
         label: 'Messages',
         renderer: messageBadgeRenderer,
         tooltip: 'Messages pending response',
         type: 'element',
     },
+    */
     {
         renderer: WorkDeleteButtonRenderer,
         type: 'action',


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-1929

- removes the messages badge from the work dashboard table
- does not make api calls to retrieve the message counts