### PR TITLE
Prod 2008 toolselectornarrow subroutes

### DIFF
--- a/src-ts/header/tool-selectors/tool-selectors-narrow/tool-selector-narrow/ToolSelectorNarrow.tsx
+++ b/src-ts/header/tool-selectors/tool-selectors-narrow/tool-selector-narrow/ToolSelectorNarrow.tsx
@@ -20,7 +20,7 @@ const ToolSelectorNarrow: FC<ToolSelectorNarrowProps> = (props: ToolSelectorNarr
     const baseClass: string = 'tool-selector-narrow'
     const isActive: boolean = routeIsActive(useLocation().pathname, path)
     const activeIndicaterClass: string = `${baseClass}-${isActive ? '' : 'in'}active`
-    const hasChildren: boolean = !!route.children.some(child => !!child.route && !isParamRoute(child.route))
+    const hasChildren: boolean = !!route.children.some(child => !!child.route && !child.uiHidden)
 
     return (
         <div className={styles[baseClass]}>

--- a/src-ts/header/tool-selectors/tool-selectors-narrow/tool-selector-narrow/ToolSelectorNarrow.tsx
+++ b/src-ts/header/tool-selectors/tool-selectors-narrow/tool-selector-narrow/ToolSelectorNarrow.tsx
@@ -10,6 +10,8 @@ interface ToolSelectorNarrowProps {
     route: PlatformRoute
 }
 
+const isParamRoute: (route: string) => boolean = (route: string) => !!route.match(/^:[^/]+$/)
+
 const ToolSelectorNarrow: FC<ToolSelectorNarrowProps> = (props: ToolSelectorNarrowProps) => {
 
     const route: PlatformRoute = props.route
@@ -18,7 +20,7 @@ const ToolSelectorNarrow: FC<ToolSelectorNarrowProps> = (props: ToolSelectorNarr
     const baseClass: string = 'tool-selector-narrow'
     const isActive: boolean = routeIsActive(useLocation().pathname, path)
     const activeIndicaterClass: string = `${baseClass}-${isActive ? '' : 'in'}active`
-    const hasChildren: boolean = !!route.children.some(child => !!child.route)
+    const hasChildren: boolean = !!route.children.some(child => !!child.route && !isParamRoute(child.route))
 
     return (
         <div className={styles[baseClass]}>

--- a/src-ts/lib/route-provider/platform-route.model.ts
+++ b/src-ts/lib/route-provider/platform-route.model.ts
@@ -8,4 +8,5 @@ export interface PlatformRoute {
     requireAuth?: boolean
     route: string
     title: string
+    uiHidden?: boolean
 }

--- a/src-ts/tools/work/work.routes.tsx
+++ b/src-ts/tools/work/work.routes.tsx
@@ -23,6 +23,7 @@ export const workRoutes: Array<PlatformRoute> = [
                 enabled: true,
                 route: ':statusKey',
                 title: toolTitle,
+                uiHidden: true,
             },
         ],
         element: <Work />,


### PR DESCRIPTION
https://topcoder.atlassian.net/browse/PROD-2008

- Handle page subroutes that should not appear in UI as 2nd menu items in ToolSelector narrow (mobile nav menu). 