### PR TITLE
PROD-2056 - make tabs navbar as column selector on mobile to fit the …

### DIFF
--- a/src-ts/lib/tabs-navbar/TabsNavbar.module.scss
+++ b/src-ts/lib/tabs-navbar/TabsNavbar.module.scss
@@ -8,6 +8,10 @@
     margin-bottom: $pad-md;
 
     position: relative;
+
+    @include ltemd {
+        flex-direction: column;
+    }
 }
 
 .tab-item {
@@ -71,4 +75,7 @@
     transform: translateX(-50%);
     
     transition: left 0.15s ease-in-out;
+    @include ltemd {
+        display: none;
+    }
 }


### PR DESCRIPTION
[PROD-2056](https://topcoder.atlassian.net/browse/PROD-2056)

- the issue was caused by the fact that the horizontal tabbed navbar didn't fit the available space on mobile
- switched to vertical navbar to make it fit the available space


The problem: 
![image](https://user-images.githubusercontent.com/2527433/170510395-bccae7a6-e1a8-4b5a-9041-09ecaacc7776.png)

you can scroll horizontally to view the rest of items:
![image](https://user-images.githubusercontent.com/2527433/170510467-c7d34ada-0481-497a-956d-b954a4b37b9d.png)


The proposed solution:
![image](https://user-images.githubusercontent.com/2527433/170510575-9ada798b-fa92-4fcc-bdb6-1f52f6b512e7.png)


NOTE: the table can be scrolled horizontally as expected.